### PR TITLE
Fix: delay type in <Link />

### DIFF
--- a/js/code-components.js
+++ b/js/code-components.js
@@ -154,7 +154,7 @@ renderSSR(<App />, { pathname: '/123456/detail' })`,
 // wait for 150ms before navigating
 // (useful if, for example, you want to fadeOut the content before navigating)
 // (together with "prefetch", your MPA will just look like a SPA ❤️)
-<Link delay="150" href="https://geckosio.github.io/">
+<Link delay={150} href="https://geckosio.github.io/">
   Link to geckos.io
 </Link>`,
   Visible: `import { Visible } from 'nano-jsx/lib/components/visible'


### PR DESCRIPTION
When I reading the implementation of `<Link />` component, I noticed delay property in `<Link />` should only be number or undefined, not string.

https://github.com/nanojsx/nano/blob/1a084b66dfb5e5af4279f70a3c90de2e83a33e10/src/components/link.ts#L68

https://github.com/nanojsx/nano/blob/1a084b66dfb5e5af4279f70a3c90de2e83a33e10/src/components/link.ts#L71

In the example of `<Link />`, delay prop is string, this will lead misunderstanding, so I fixed it. 