### PR TITLE
Chore: write Documentation about dangelouslySetInnerHTML

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -108,6 +108,11 @@
         <h2>Fragment</h2>
         <pre><code id="fragment" class="language-tsx">loading...</code></pre>
 
+        <h2>dangerouslySetInnerHTML</h2>
+        <p>Nano JSX escapes text as a default behavior, this behavior protects your application from crises such as XSS attacks, but sometimes you want not to escape text. Nano JSX provides API for that time as well as React.</p>
+        <p><strong>dangerouslySetInnerHTML</strong>, this naming is same as React, allows you to set HTML directly.</p>
+        <pre><code id="dangerouslySetInnerHTML" class="language-tsx">loading...</code></pre>
+
         <h2>CustomElementsMode</h2>
         <pre><code id="customElementsMode" class="language-tsx">loading...</code></pre>
         <pre><code id="customElementsModeHTML" class="language-html">loading...</code></pre>

--- a/js/code-docs.js
+++ b/js/code-docs.js
@@ -215,7 +215,18 @@ Nano.defineAsCustomElements(
   }
 )
 `,
-customElementsModeHTML: `<body>
+  dangerouslySetInnerHTML: `
+const html = \`<div> your markup</div>\`;
+
+const App = () => {
+  return <div
+    dangerouslySetInnerHTML={{
+      __html: html
+    }}
+  />;
+}
+`,
+  customElementsModeHTML: `<body>
   <h1>Hello Nano JSX customElementsMode</h1>
   <nano-component value='hello'></nano-component>
   <script src='your custom elements script'></script>


### PR DESCRIPTION
## Motivation :fire:

Fix : https://github.com/nanojsx/nano/issues/54

I wrote docs about dangelouslySetInnerHTML.

## Screenshot

![スクリーンショット 2021-11-20 22 25 23 1](https://user-images.githubusercontent.com/42742053/142728036-24fb576d-dca0-4cd4-a23e-0ee0309872f8.png)

## Note 🗒️ 

Should I write docs about dangerouslySetInnerHTML also in `nano-jsx/nano`'s README?
