### PR TITLE
Add example dot list

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -43,21 +43,33 @@
 
       <section>
         <h1>Examples</h1>
+        <ul class="dot-list">
+          <li><a href="#todoList">Todo List</a></li>
+          <li><a href="#clock">Clock</a></li>
+          <li><a href="#checkbox">Checkbox</a></li>
+          <li><a href="#fetch">Fetch Data</a></li>
+          <li><a href="#fetchSuspense">Fetch Data (with Suspense)</a></li>
+          <li><a href="#fetchSuspenseIsomorphic">Fetch Data (with Suspense + isomorphic)</a></li>
+          <li><a href="#lazyImgFadein">Lazy Image Fadein</a></li>
+          <li><a href="#store">Store</a></li>
+          <li><a href="#ssr">SSR</a></li>
+          <li><a href="#taggedTemplates">Tagged Template Literals</a></li>
+        </ul>
 
-        <h2>Todo List</h2>
-        <pre><code id="todoList" class="language-tsx">loading...</code></pre>
+        <h2 id="todoList">Todo List</h2>
+        <pre><code id="TodoList" class="language-tsx">loading...</code></pre>
 
-        <h2>Clock</h2>
-        <pre><code id="clock" class="language-tsx">loading...</code></pre>
+        <h2 id="clock">Clock</h2>
+        <pre><code id="Clock" class="language-tsx">loading...</code></pre>
 
-        <h2>Checkbox</h2>
-        <pre><code id="checkbox" class="language-tsx">loading...</code></pre>
+        <h2 id="checkbox">Checkbox</h2>
+        <pre><code id="Checkbox" class="language-tsx">loading...</code></pre>
 
-        <h2>Fetch Data</h2>
+        <h2 id="fetch">Fetch Data</h2>
         <p>Fetch data inside didMount().</p>
-        <pre><code id="fetch" class="language-tsx">loading...</code></pre>
+        <pre><code id="Fetch" class="language-tsx">loading...</code></pre>
 
-        <h2>Fetch Data (with Suspense)</h2>
+        <h2 id="fetchSuspense">Fetch Data (with Suspense)</h2>
         <p>
           Fetch data with <code class="is-code">&lt;Suspense /&gt;</code>. In this example Suspense gets the props names
           as a promise (<small>a function that returns a promise</small>,
@@ -66,30 +78,30 @@
           <br />
           Add <code class="is-code">cache</code> if you want to cache the result of the promise.
         </p>
-        <pre><code id="fetchSuspense" class="language-tsx">loading...</code></pre>
+        <pre><code id="FetchSuspense" class="language-tsx">loading...</code></pre>
 
-        <h2>Fetch Data (with Suspense + isomorphic)</h2>
+        <h2 id="fetchSuspenseIsomorphic">Fetch Data (with Suspense + isomorphic)</h2>
         <p>
           Of course <code class="is-code">&lt;Suspense /&gt;</code> works also on the server-side. To make the App
           Component from the above example work isomorphic, modify it as following:
         </p>
-        <pre><code id="fetchSuspenseIsomorphic" class="language-tsx">loading...</code></pre>
+        <pre><code id="FetchSuspenseIsomorphic" class="language-tsx">loading...</code></pre>
 
-        <h2>Lazy Image Fadein</h2>
+        <h2 id="lazyImgFadein">Lazy Image Fadein</h2>
         <p>A simple component that smoothly fades in your lazy loaded images.</p>
-        <pre><code id="lazyImgFadein" class="language-tsx">loading...</code></pre>
+        <pre><code id="LazyImgFadein" class="language-tsx">loading...</code></pre>
 
-        <h2>Store</h2>
+        <h2 id="store">Store</h2>
         <p>Use an external store, to store your application's state.</p>
-        <pre><code id="store" class="language-tsx">loading...</code></pre>
+        <pre><code id="Store" class="language-tsx">loading...</code></pre>
 
-        <h2>SSR</h2>
+        <h2 id="ssr">SSR</h2>
         <p>SSR example with the built-in Helmet component.</p>
-        <pre><code id="ssr" class="language-tsx">loading...</code></pre>
+        <pre><code id="Ssr" class="language-tsx">loading...</code></pre>
 
-        <h2>Tagged Template Literals</h2>
+        <h2 id="taggedTemplates">Tagged Template Literals</h2>
         <p>You can use jsx without any build tools, if you want.</p>
-        <pre><code id="taggedTemplates" class="language-tsx">loading...</code></pre>
+        <pre><code id="TaggedTemplates" class="language-tsx">loading...</code></pre>
       </section>
 
       <footer class="is-full-width has-background-light">

--- a/js/code-examples.js
+++ b/js/code-examples.js
@@ -1,5 +1,5 @@
 const code = {
-  todoList: `import Nano, { Component } from 'nano-jsx'
+  TodoList: `import Nano, { Component } from 'nano-jsx'
 
 class Todos extends Component {
   todos: string[] = []
@@ -30,7 +30,7 @@ class Todos extends Component {
 }
 
 Nano.render(<Todos />, document.getElementById('root'))`,
-  clock: `class Clock extends Component {
+  Clock: `class Clock extends Component {
   time = Date.now()
   timer: number
 
@@ -54,7 +54,7 @@ Nano.render(<Todos />, document.getElementById('root'))`,
 
 // render an instance of Clock into <body>:
 Nano.render(<Clock />, document.body)`,
-  checkbox: `class Checkbox extends Component {
+  Checkbox: `class Checkbox extends Component {
   checked = true
 
   toggle = (e: Event) => {
@@ -75,7 +75,7 @@ Nano.render(<Clock />, document.body)`,
 }
 
 Nano.render(<Checkbox />, document.body)`,
-  fetch: `const fetchNames = async () => {
+  Fetch: `const fetchNames = async () => {
   const res = await fetch('https://jsonplaceholder.typicode.com/users')
   const json = await res.json()
   const names = json.map((obj) => obj.name)
@@ -104,7 +104,7 @@ class Names extends Component {
   }
 }
 `,
-  fetchSuspense: `// fetch a list of names from the server
+  FetchSuspense: `// fetch a list of names from the server
 const fetchNames = async () => {
   const res = await fetch('https://jsonplaceholder.typicode.com/users')
   const json = await res.json()
@@ -133,7 +133,7 @@ const App = () => (
     </Suspense>
   </div>
 )
-`, fetchSuspenseIsomorphic: `// app component
+`, FetchSuspenseIsomorphic: `// app component
 class App extends Component {
 
   // a empty static method
@@ -159,7 +159,7 @@ const names = await fetchNames() // prefetch names
 App.fetchNames = () => () => names // overwrite the static method
 Nano.renderSSR(<App />) // render
 `,
-  lazyImgFadein: `import Nano, { Img, Helmet } from 'nano-jsx'
+  LazyImgFadein: `import Nano, { Img, Helmet } from 'nano-jsx'
 
 // create your component
 const MyLazyImg = (props: any) => {
@@ -197,7 +197,7 @@ const MyLazyImg = (props: any) => {
 
 // use your component
 <MyLazyImg width="350" height="150" src="https://via.placeholder.com/350x150" />`,
-  store: `// import Nano, Component and Store
+  Store: `// import Nano, Component and Store
 import Nano, { Component, Store } from '../index'
 
 // initialize the store with a default value
@@ -246,7 +246,7 @@ class App extends Component {
 }
 
 Nano.render(<App />, document.getElementById('root'))`,
-  ssr: `// server.tsx
+  Ssr: `// server.tsx
 import Nano, { Img, Helmet } from 'nano-jsx'
 
 const App = () => {
@@ -285,7 +285,7 @@ const html = \`
 \`
 
 // now send the html to the client`,
-  taggedTemplates: `<script>
+  TaggedTemplates: `<script>
   const { render, jsx, Link } = nanoJSX
 
   const names = ['joe', 'suzanne']


### PR DESCRIPTION
### Reference Issues/PRs

None

### What does this implement/fix?

- Added a dot-list to Examples like on the Component site

For me this is important, since I'm using the Docs/Examples often and always have to scroll down, since I can't remember on which of the 4 sites the code I'm looking for is to find.